### PR TITLE
Fix small typo in PSL_catalog.json

### DIFF
--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -33,5 +33,5 @@
         "source": null,
         "type": "html",
         "data": "<a href=\"https://github.com/PSLmodels/capital-cost-recovery/blob/master/source_documentation.md\"></a>"
-    },
+    }
 }


### PR DESCRIPTION
This PR removes an extra comma in `PSL_catalog.json` so that we can add the project to the PSL catalog. Thanks for your work on this project!