### PR TITLE
Update PSL_catalog.json

### DIFF
--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -12,7 +12,7 @@
             "name": "Daniel Bunn",
             "image": "https://avatars.githubusercontent.com/u/52042494?v=4",
             "link": "https://github.com/danielbunn"
-        },
+        }
     ],
     "links": {
       "code_repository": "https://github.com/TaxFoundation/capital-cost-recovery",


### PR DESCRIPTION
Fixes the format of `PSL_catalog.json`, which had an extraneous comma.

cc @amengden 